### PR TITLE
Support a specific nightly release

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,4 @@
 const os = require('os')
-const path = require('path')
 
 function mapArch (arch) {
   const mappings = {
@@ -11,8 +10,9 @@ function mapArch (arch) {
 }
 
 function getDownloadObject (version) {
+  const version_name = version.replace(/^nightly-[0-9a-f]{40}$/, "nightly");
   const platform = os.platform()
-  const filename = `foundry_${version}_${platform}_${mapArch(os.arch())}`
+  const filename = `foundry_${version_name}_${platform}_${mapArch(os.arch())}`
   const extension = platform === 'win32' ? 'zip' : 'tar.gz'
   const url = `https://github.com/gakonst/foundry/releases/download/${version}/${filename}.${extension}`
 


### PR DESCRIPTION
Fixes https://github.com/onbjerg/foundry-toolchain/issues/3

Adds support for using a specific nightly release to run CI on, e.g. https://github.com/gakonst/foundry/releases/tag/nightly-6547691c6123c1bdbed770fcd245f1e63092befe.